### PR TITLE
Use QLocale instead of SystemLanguage().

### DIFF
--- a/converter_gui.py
+++ b/converter_gui.py
@@ -3,7 +3,7 @@
 
 #Core of the GUI and image process
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QApplication, QPushButton, QCheckBox, QFileDialog
-from PyQt5.QtCore    import QTranslator
+from PyQt5.QtCore    import QTranslator, QLocale
 import cv2
 import numpy as np
 import math
@@ -84,32 +84,7 @@ class SettingsGUI(QWidget):
         if self.btn_finish_rect.isChecked():
             rimg = rect.rectify( img )
             cv2.imwrite(file_name + ".rect.png", rimg)
-        
 
-
-
-def SystemLanguage():
-    import platform
-    ostype = platform.system()
-    loc = []
-    if ostype == "Darwin":
-        #for macos
-        import re
-        output = subprocess.check_output(["defaults","read","-g","AppleLanguages"])
-        output = output.decode('utf-8')
-        for l in output.split("\n")[1:len(output)-2]:
-            lang = re.sub(r'[ "]+', '', l)
-            loc.append(lang)
-        return loc[0]
-        #print(loc)
-    elif ostype == "Windows":
-        import ctypes
-        import locale
-        windll = ctypes.windll.kernel32
-        loc = locale.windows_locale[ windll.GetUserDefaultUILanguage() ]
-        return loc
-    return loc
-    
 #for pyinstaller
 def resource_path(relative):
     return os.path.join(
@@ -126,8 +101,7 @@ def main():
     app = QApplication(sys.argv)
     translator = QTranslator(app)
     rpath = getattr(sys, '_MEIPASS', os.getcwd())
-    loc = SystemLanguage()
-    if loc[:2] == "ja":
+    if QLocale.system().language() == QLocale.Japanese:
         translator.load(rpath+"/i18n/trainscanner_ja")
     app.installTranslator(translator)
     se = SettingsGUI()

--- a/trainscanner_gui.py
+++ b/trainscanner_gui.py
@@ -4,7 +4,7 @@
 #Core of the GUI and image process
 from PyQt5.QtWidgets import QWidget, QLabel, QPushButton, QDialog, QApplication, QProgressBar, QVBoxLayout, QScrollArea, QHBoxLayout, QGroupBox, QGridLayout, QSlider, QCheckBox, QSpinBox, QFileDialog, QRubberBand
 from PyQt5.QtGui     import QImage, QPixmap, QPainter
-from PyQt5.QtCore    import QObject, pyqtSignal, QThread, Qt, QPoint, QTranslator, QRect, QSize
+from PyQt5.QtCore    import QObject, pyqtSignal, QThread, Qt, QPoint, QTranslator, QRect, QSize, QLocale
 
 import cv2
 import numpy as np
@@ -971,28 +971,6 @@ class EditorGUI(QWidget):
     #This will be the trigger for the first rendering
     #def resizeEvent(self, event):
     #    self.asyncimageloader.render()
-
-
-def SystemLanguage():
-    import platform
-    ostype = platform.system()
-    loc = []
-    if ostype == "Darwin":
-        #for macos
-        import re
-        output = subprocess.check_output(["defaults","read","-g","AppleLanguages"])
-        output = output.decode('utf-8')
-        for l in output.split("\n")[1:len(output)-2]:
-            lang = re.sub(r'[ "]+', '', l)
-            loc.append(lang)
-        return loc[0]
-    elif ostype == "Windows":
-        import ctypes
-        import locale
-        windll = ctypes.windll.kernel32
-        loc = locale.windows_locale[ windll.GetUserDefaultUILanguage() ]
-        return loc
-    return loc
     
 #for pyinstaller
 def resource_path(relative):
@@ -1026,8 +1004,7 @@ def main():
     app = QApplication(sys.argv)
     translator = QTranslator(app)
     rpath = getattr(sys, '_MEIPASS', os.getcwd())
-    loc = SystemLanguage()
-    if loc[:2] == "ja":
+    if QLocale.system().language() == QLocale.Japanese:
         translator.load(rpath+"/i18n/trainscanner_ja")
     app.installTranslator(translator)
     debug = False


### PR DESCRIPTION
SystemLanguage関数はMac OS XまたはWindowsで動作しますが、Linux上では動作しません。  
そのためLinux上では翻訳ファイルを読み込む処理が行われず、OSの言語が日本語でもUIの言語が英語になります。  
QLocaleクラスはあらゆるOSでOSの言語を取得可能で、OS固有のコードを書く必要がありません。    
Linuxでも問題なく動作します。
