### PR TITLE
Fix argument bug

### DIFF
--- a/ts_conv/film.py
+++ b/ts_conv/film.py
@@ -3,6 +3,7 @@
 import cv2
 import numpy as np
 import math
+import argparse
 import sys
 
 def roundbox(img,p1,p2,r,color):
@@ -59,23 +60,30 @@ def filmify(img, label=""):
         cv2.putText(canvas,label,(int(perf*0.5),int(canh)),font,fontsize,(0,150,200),thick)
     return canvas
 
-
+def prepare_parser():
+    parser = argparse.ArgumentParser(description='Filmify', fromfile_prefix_chars='@',)
+    parser.add_argument('-c', '--creative_commons_sign', type=str, metavar='string',
+                        default="",
+                        dest="creative_commons_sign",
+                        help="Add Creative Commons sign.")
+    parser.add_argument('-o', '--output', type=str, metavar='outfilename',
+                        default="",
+                        dest="output",
+                        help="Output file name.")
+    parser.add_argument('filename', type=str,
+                        help="Image file name.")
+    return parser
 
 def main():
-    #if you want to add Creative Commons sign,
-    cc = ""
-    while len(sys.argv) > 2:
-        option = sys.argv.pop(1)
-        if option == "-c":
-            cc = sys.argv.pop(1)
-
-    if len(sys.argv) != 2:
-        print("usage: {0} image".format(sys.argv[0]))
-        sys.exit(1)
-
-    img = cv2.imread(sys.argv[1])
-    canvas = filmify( img, label=cc )
-    cv2.imwrite("{0}.film.png".format(sys.argv[1]), canvas)
+    parser = prepare_parser()
+    params = parser.parse_args(sys.argv[1:])
+    print(params.filename)
+    img = cv2.imread(params.filename)
+    canvas = filmify( img, label=params.creative_commons_sign)
+    if params.output == "":
+        cv2.imwrite("{0}.film.png".format(params.filename), canvas)
+    else:
+        cv2.imwrite(params.output, canvas)
 
 if __name__ == "__main__":
     main()

--- a/ts_conv/helix.py
+++ b/ts_conv/helix.py
@@ -102,7 +102,7 @@ def prepare_parser():
     parser.add_argument('-m', '--margin', type=float, metavar='x',
                         default=0,
                         dest="margin",
-                        help="Add margin of x % of the wider edge around the image.")
+                        help="Add margin of x %% of the wider edge around the image.")
     parser.add_argument('-a', '--aspect', type=float, metavar='x',
                         default=2.0**0.5,
                         dest="aspect",

--- a/ts_conv/rect.py
+++ b/ts_conv/rect.py
@@ -62,7 +62,7 @@ def main():
     if params.output == "":
         cv2.imwrite("{0}.rect.jpg".format(params.filename), canvas)
     else:
-        cv2.imwrite(params.output, canvas2)
+        cv2.imwrite(params.output, canvas)
     
 if __name__ == "__main__":
     main()

--- a/ts_conv/rect.py
+++ b/ts_conv/rect.py
@@ -39,7 +39,7 @@ def prepare_parser():
     parser.add_argument('-g', '--gap', type=int, metavar='x',
                         default=0,
                         dest="gap",
-                        help="Add gaps of x % between the rows.")
+                        help="Add gaps of x %% between the rows.")
     parser.add_argument('-r', '--rows', type=int, metavar='x',
                         default=None,
                         dest="rows",


### PR DESCRIPTION
以下の不具合の修正と機能の追加をしました。

* `helicify`コマンドと`rectify`コマンドに`-h`オプションをつけて実行するとクラッシュする不具合
* `rectify`コマンドに`-o`オプションでファイル名を指定するとクラッシュする不具合
* `filmify`コマンドに`-h`オプションと`-o`オプションが無かったので追加

修正前の`helicify`コマンドと`rectify`コマンドの出力を張っておきます。
```sh
$ helicify -h
Traceback (most recent call last):
  File "/usr/local/bin/helicify", line 11, in <module>
    load_entry_point('TrainScanner==0.9.7', 'console_scripts', 'helicify')()
  File "/usr/local/lib/python3.6/site-packages/TrainScanner-0.9.7-py3.6.egg/ts_conv/helix.py", line 121, in main
    params = parser.parse_args(sys.argv[1:])
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 1730, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 1762, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 1968, in _parse_known_args
    start_index = consume_optional(start_index)
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 1908, in consume_optional
    take_action(action, args, option_string)
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 1836, in take_action
    action(self, namespace, argument_values, option_string)
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 1020, in __call__
    parser.print_help()
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 2362, in print_help
    self._print_message(self.format_help(), file)
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 2346, in format_help
    return formatter.format_help()
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 282, in format_help
    help = self._root_section.format_help()
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 213, in format_help
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 213, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 213, in format_help
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 213, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 519, in _format_action
    help_text = self._expand_help(action)
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 606, in _expand_help
    return self._get_help_string(action) % params
TypeError: %o format: an integer is required, not dict
```

```sh
$ rectify -h
Traceback (most recent call last):
  File "/usr/local/bin/rectify", line 11, in <module>
    load_entry_point('TrainScanner==0.9.7', 'console_scripts', 'rectify')()
  File "/usr/local/lib/python3.6/site-packages/TrainScanner-0.9.7-py3.6.egg/ts_conv/rect.py", line 58, in main
    params = parser.parse_args(sys.argv[1:])
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 1730, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 1762, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 1968, in _parse_known_args
    start_index = consume_optional(start_index)
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 1908, in consume_optional
    take_action(action, args, option_string)
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 1836, in take_action
    action(self, namespace, argument_values, option_string)
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 1020, in __call__
    parser.print_help()
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 2362, in print_help
    self._print_message(self.format_help(), file)
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 2346, in format_help
    return formatter.format_help()
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 282, in format_help
    help = self._root_section.format_help()
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 213, in format_help
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 213, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 213, in format_help
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 213, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 519, in _format_action
    help_text = self._expand_help(action)
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/argparse.py", line 606, in _expand_help
    return self._get_help_string(action) % params
ValueError: unsupported format character 'b' (0x62) at index 16
```

```sh
$ rectify -o example.rect.png example.png
example.png
Traceback (most recent call last):
  File "/usr/local/bin/rectify", line 11, in <module>
    load_entry_point('TrainScanner==0.9.7', 'console_scripts', 'rectify')()
  File "/usr/local/lib/python3.6/site-packages/TrainScanner-0.9.7-py3.6.egg/ts_conv/rect.py", line 65, in main
    cv2.imwrite(params.output, canvas2)
NameError: name 'canvas2' is not defined
```
