### PR TITLE
Fixed: trainscanner crashes when stitch_gui.StitcherUI window appears.

### DIFF
--- a/trainscanner/trainscanner_gui.py
+++ b/trainscanner/trainscanner_gui.py
@@ -672,6 +672,7 @@ class SettingsGUI(QWidget):
         file_name = stitcher.stitcher.outfilename
         stitcher.setMaximumHeight(500)
         stitcher.showMaximized()
+        stitcher.exec_()
         stitcher = None
 
     def closeEvent(self,event):


### PR DESCRIPTION
TrainScanner GUIでpass1_gui.MatcherUIからstitch_gui.StitcherUIに切り替わるタイミングで以下のエラーが発生することがあります。

QThread: Destroyed while thread is still running
Abort trap: 6

スタックトレースを見るとQThreadのデストラクタが呼び出されていました。おそらくmatcher.exec_()と同様にstitcher.exec_()が必要のようです。Qtは詳しくないので修正方法が正しいかどうか分かりませんが、私の環境(macOS 10.14.6 + Homebrew版Python3.7.4)では、この修正で改善しています。