### PR TITLE
 Fixed: setThumbs() may cause ZeroDivisionError

### DIFF
--- a/trainscanner/imageselector2.py
+++ b/trainscanner/imageselector2.py
@@ -22,6 +22,9 @@ class ImageSelector2(QWidget):
         
         
     def setThumbs(self, thumbs):
+        if len(thumbs) < 2:
+            return
+
         #move the slide bar and trim indicator
         lastlen = len(self.imagebar.thumbs)
         lasthead = self.slider.start()


### PR DESCRIPTION
私の低速Ubuntuマシン(Intel(R) Core(TM) i3-7100U CPU @ 2.40GHz)でα7RIIIの動画(h264 avc1)を読み込ませようとするとImageSelector2.setThumbs()に長さが1個のthumbsが渡されて ZeroDivisionErrorが発生する場合がありましたので、お知らせいたします。
おそらくEditorGUI.updateTimeLine()内の now - self.lastupdatethumbs < 0.2 をもっと長い時間にすればよいのかもしれませんが、レスポンスが悪くなると思いましたので、setThumbs()のほうで len(thumbs) < 2 のときは setMax(len(thumbs)-1) を回避するようにしてみました。

> (env) foo@bar:~/temp/trainscanner_test/TrainScanner$ trainscanner
> Traceback (most recent call last):
>   File ".../env/lib/python3.8/site-packages/trainscanner/trainscanner_gui.py", line 916, in sliderTL_on_draw
>     self.updateTimeLine(self.asyncimageloader.snapshots)
>   File ".../env/lib/python3.8/site-packages/trainscanner/trainscanner_gui.py", line 765, in updateTimeLine
>     self.imageselector2.setThumbs(cv2thumbs)
>   File ".../env/lib/python3.8/site-packages/trainscanner/imageselector2.py", line 34, in setThumbs
>     self.slider.setStart(lasthead)
>   File ".../env/lib/python3.8/site-packages/trainscanner/qrangeslider.py", line 447, in setStart
>     v = self._valueToPos(value)
>   File ".../env/lib/python3.8/site-packages/trainscanner/qrangeslider.py", line 540, in _valueToPos
>     return scale(value, (self.min(), self.max()), (0, self.width() - self._splitter.handleWidth()*2))
>   File ".../env/lib/python3.8/site-packages/trainscanner/qrangeslider.py", line 109, in scale
>     return int(((val - src[0]) / float(src[1]-src[0])) * (dst[1]-dst[0]) + dst[0])
> ZeroDivisionError: float division by zero
