### PR TITLE
stitch_guiの画面表示が異常に遅くなる問題を修正しました。

### DIFF
--- a/trainscanner/stitch_gui.py
+++ b/trainscanner/stitch_gui.py
@@ -75,7 +75,7 @@ class ExtensibleCanvasWidget(QLabel):
 
     def updatePixmap(self, pos, image):
         self.scaled_canvas.put_image(pos, image)
-        fullimage = self.scaled_canvas.get_image()[:, :, ::-1].copy()  # reverse order
+        fullimage = cv2.cvtColor(self.scaled_canvas.get_image(), cv2.COLOR_BGR2RGB)  # reverse order
         h, w = fullimage.shape[:2]
         self.resize(w, h)
         qimage = QImage(fullimage.data, w, h, w * 3, QImage.Format.Format_RGB888)


### PR DESCRIPTION
Windows用インストーラの動作確認をしていたところ、ステッチング中の画面表示が非常に重くなる現象がWindows上で発生していました。
デバッガで調べたところ、ステッチング画像が次第に大きくなるにつれupdatePixmapメソッドのnp.ndarray.copy()が遅くなっていくことが判りました。BGRをRGBに入れ替える処理でしたのでcv2.cvtColorに置き換えたところ、処理の負荷がかなり軽減されることをWindowsで確認しています。
Macでは未確認です。ご確認頂けると幸いです。
